### PR TITLE
Strict-mode leases (exec --leased, fail-closed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `llm-secrets` will be documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Strict-mode leases** (#15). `exec --leased` (also `exec --profile … --leased` and `profile exec … --leased`) now requires a current lease for every injected secret and **fails closed** if none is held. An expired lease counts as no lease. The default `exec` path is unchanged — strict mode is opt-in.
+
 ## [3.0.0] — 2026-04-10
 
 **XDG-compliant store location.** The default store directory moves from `~/.llm-secrets/` to `~/.local/share/llm-secrets/` (XDG_DATA_HOME). Config stays at `~/.config/llm-secrets/` (profiles.toml). Both paths are now XDG-compliant.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,6 +152,10 @@ ENV=key mappings. Equivalent to `llms profile exec`.
         /// Present a macaroon (also honoured: $LLM_SECRETS_MACAROON)
         #[arg(long)]
         macaroon: Option<String>,
+        /// Strict mode: require a current lease for every injected secret,
+        /// failing closed if none is held (see `llms lease`).
+        #[arg(long)]
+        leased: bool,
         /// Command to run
         #[arg(last = true, required = true)]
         command: Vec<String>,
@@ -325,6 +329,10 @@ enum ProfileCommand {
         /// Override the profile's default TTL
         #[arg(long)]
         ttl: Option<String>,
+        /// Strict mode: require a current lease for every injected secret,
+        /// failing closed if none is held (see `llms lease`).
+        #[arg(long)]
+        leased: bool,
         /// Command to run
         #[arg(last = true, required = true)]
         command: Vec<String>,
@@ -393,17 +401,18 @@ pub fn run() -> Result<()> {
             profile,
             ttl,
             macaroon,
+            leased,
             command,
         } => {
             if let Some(name) = profile {
-                cmd_profile_exec(&name, ttl, command)
+                cmd_profile_exec(&name, ttl, command, leased)
             } else {
                 if inject.is_empty() {
                     return Err(Error::Other(
                         "exec requires --inject ENV=key (or --profile <name>)".into(),
                     ));
                 }
-                cmd_exec(inject, macaroon, command)
+                cmd_exec(inject, macaroon, command, leased)
             }
         }
         Command::Status => cmd_status(),
@@ -430,7 +439,12 @@ pub fn run() -> Result<()> {
             ProfileCommand::List => cmd_profile_list(),
             ProfileCommand::Show { name } => cmd_profile_show(&name),
             ProfileCommand::Mint { name, ttl } => cmd_profile_mint(&name, ttl),
-            ProfileCommand::Exec { name, ttl, command } => cmd_profile_exec(&name, ttl, command),
+            ProfileCommand::Exec {
+                name,
+                ttl,
+                leased,
+                command,
+            } => cmd_profile_exec(&name, ttl, command, leased),
         },
     }
 }
@@ -604,13 +618,26 @@ fn cmd_status() -> Result<()> {
     Ok(())
 }
 
-fn cmd_exec(inject: Vec<String>, macaroon: Option<String>, command: Vec<String>) -> Result<()> {
+fn cmd_exec(
+    inject: Vec<String>,
+    macaroon: Option<String>,
+    command: Vec<String>,
+    leased: bool,
+) -> Result<()> {
     if command.is_empty() {
         return Err(Error::Other("no command provided after `--`".into()));
     }
 
     let identity = store::load_identity()?;
     let store = store::load_store(&identity)?;
+
+    // Strict mode (#15): every injected secret must hold a current lease, or we
+    // fail closed before any plaintext is touched.
+    let leases = if leased {
+        Some(crate::lease::LeaseSet::load()?)
+    } else {
+        None
+    };
 
     let mut process = ProcessCommand::new(&command[0]);
     process.args(&command[1..]);
@@ -626,6 +653,9 @@ fn cmd_exec(inject: Vec<String>, macaroon: Option<String>, command: Vec<String>)
         let (env_var, secret_key) = spec
             .split_once('=')
             .ok_or_else(|| Error::Other(format!("invalid --inject {spec:?}, expected ENV=key")))?;
+        if let Some(leases) = &leases {
+            leases.require_active(secret_key)?;
+        }
         let ctx = gate(secret_key, &macaroon)?;
         let value = store
             .get(secret_key)
@@ -896,7 +926,12 @@ fn cmd_profile_mint(name: &str, ttl_override: Option<String>) -> Result<()> {
     Ok(())
 }
 
-fn cmd_profile_exec(name: &str, ttl_override: Option<String>, command: Vec<String>) -> Result<()> {
+fn cmd_profile_exec(
+    name: &str,
+    ttl_override: Option<String>,
+    command: Vec<String>,
+    leased: bool,
+) -> Result<()> {
     if command.is_empty() {
         return Err(Error::Other("no command provided after `--`".into()));
     }
@@ -928,7 +963,7 @@ fn cmd_profile_exec(name: &str, ttl_override: Option<String>, command: Vec<Strin
         Some(format!("profile={} command={}", p.name, command[0])),
     );
 
-    cmd_exec(inject, Some(encoded), command)
+    cmd_exec(inject, Some(encoded), command, leased)
 }
 
 /// Read a macaroon from `--macaroon`, or `LLM_SECRETS_MACAROON`, or stdin

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -92,12 +92,24 @@ impl LeaseSet {
         before - self.leases.len()
     }
 
-    #[allow(dead_code)] // used by `exec --leased` enforcement (planned)
     pub fn active_for(&self, key: &str) -> Option<&Lease> {
         self.leases
             .iter()
             .filter(|l| l.key == key && !l.is_expired())
             .max_by_key(|l| l.expires_at)
+    }
+
+    /// Strict-mode gate (`exec --leased`): the key must hold a current lease,
+    /// otherwise fail closed. An expired lease counts as no lease.
+    pub fn require_active(&self, key: &str) -> Result<()> {
+        if self.active_for(key).is_some() {
+            Ok(())
+        } else {
+            Err(Error::PolicyDenied {
+                key: key.to_string(),
+                reason: "strict mode (--leased): no active lease — run `llms lease <key> --ttl <dur>` first".to_string(),
+            })
+        }
     }
 }
 
@@ -276,5 +288,42 @@ mod tests {
         assert_eq!(removed, 1);
         assert_eq!(set.leases.len(), 1);
         assert_eq!(set.leases[0].key, "active");
+    }
+
+    #[test]
+    fn require_active_is_fail_closed() {
+        let now = Utc::now();
+        let held = LeaseSet {
+            leases: vec![Lease {
+                key: "live".into(),
+                granted_at: now,
+                expires_at: now + Duration::hours(1),
+                session_who: "u".into(),
+                session_repo: "r".into(),
+                session_agent: "a".into(),
+                session_pid: 1,
+            }],
+        };
+        // held + current -> allowed
+        assert!(held.require_active("live").is_ok());
+        // never leased -> denied (fail closed)
+        assert!(matches!(
+            held.require_active("missing"),
+            Err(crate::error::Error::PolicyDenied { .. })
+        ));
+
+        // an expired lease counts as no lease -> denied
+        let expired = LeaseSet {
+            leases: vec![Lease {
+                key: "live".into(),
+                granted_at: now - Duration::hours(2),
+                expires_at: now - Duration::seconds(1),
+                session_who: "u".into(),
+                session_repo: "r".into(),
+                session_agent: "a".into(),
+                session_pid: 1,
+            }],
+        };
+        assert!(expired.require_active("live").is_err());
     }
 }


### PR DESCRIPTION
## What

Adds `exec --leased`: a strict, fail-closed mode where every injected secret must hold a **current lease**, or the command is refused before any plaintext is touched. Also wired into `exec --profile … --leased` and `profile exec … --leased`.

## Why

Closes #15. Until now `LeaseSet::active_for` was stubbed `#[allow(dead_code)]` — leases could be granted but never *enforced*. This gives them teeth: with `--leased`, a policy allow is no longer sufficient; you must also hold an unexpired lease. An expired lease counts as no lease.

The default `exec` path is **unchanged** — strict mode is strictly opt-in, so existing flows are unaffected (as the lease module's doc comment anticipated: "v1 can flip the default").

## How

- New `LeaseSet::require_active(key)` gate → `Error::PolicyDenied` when no current lease (gives `active_for` its first caller; drops the `dead_code` allow).
- `cmd_exec` loads the lease set once when `--leased` and checks each secret before injecting.
- `--leased` flag on both the top-level `exec` and the `profile exec` subcommand.

## Verification

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all clean (new unit test `require_active_is_fail_closed` covers held / missing / expired).
- End-to-end in an isolated store: no lease → fails closed (exit 1, no leak); lease granted → succeeds; default non-strict exec → unchanged.