### PR TITLE
profile show: cross-check referenced secrets exist in the store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 ### Added
 
 - **Strict-mode leases** (#15). `exec --leased` (also `exec --profile … --leased` and `profile exec … --leased`) now requires a current lease for every injected secret and **fails closed** if none is held. An expired lease counts as no lease. The default `exec` path is unchanged — strict mode is opt-in.
+- **`profile show` cross-checks the store** (#16). `profile show` now warns (yellow on a TTY, plain otherwise) when a profile references a secret that does not exist in the live store. It stays a warning, never an error, so `show` still works without a store.
 
 ## [3.0.0] — 2026-04-10
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -883,6 +883,29 @@ fn cmd_profile_list() -> Result<()> {
     Ok(())
 }
 
+/// Print a warning to stderr — yellow when stderr is a TTY and `NO_COLOR` is
+/// unset, plain otherwise (so pipes and CI stay clean).
+fn warn(msg: &str) {
+    use std::io::IsTerminal;
+    if std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
+        eprintln!("\x1b[33mwarning:\x1b[0m {msg}");
+    } else {
+        eprintln!("warning: {msg}");
+    }
+}
+
+/// Referenced secrets that are absent per `exists`, deduped, in first-occurrence
+/// order. Pure helper so the cross-check logic is testable without a store.
+fn missing_from_store(referenced: &[String], exists: impl Fn(&str) -> bool) -> Vec<&str> {
+    let mut seen = std::collections::BTreeSet::new();
+    referenced
+        .iter()
+        .map(String::as_str)
+        .filter(|k| seen.insert(*k))
+        .filter(|k| !exists(k))
+        .collect()
+}
+
 fn cmd_profile_show(name: &str) -> Result<()> {
     let p = crate::profile::Profile::load(name)?;
     println!("profile:  {}", p.name);
@@ -907,6 +930,23 @@ fn cmd_profile_show(name: &str) -> Result<()> {
         println!("caveats:  (none beyond secrets+ttl)");
     } else {
         println!("caveats:  {}", extras.join(", "));
+    }
+
+    // #16: cross-check that every referenced secret exists in the live store.
+    // A warning, never an error — `show` must work even without a store.
+    match store::load_identity().and_then(|id| store::load_store(&id)) {
+        Ok(store) => {
+            let missing = missing_from_store(&p.secrets, |k| store.contains(k));
+            if !missing.is_empty() {
+                warn(&format!(
+                    "profile '{}' references secrets not in the store: {}",
+                    p.name,
+                    missing.join(", ")
+                ));
+            }
+        }
+        Err(Error::StoreNotFound) => {} // no store yet — nothing to verify against
+        Err(e) => warn(&format!("could not read store to verify secrets: {e}")),
     }
     Ok(())
 }
@@ -984,4 +1024,31 @@ fn read_macaroon_input(flag: Option<String>) -> Result<String> {
         ));
     }
     Ok(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_from_store_reports_only_absent_deduped() {
+        let referenced = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "a".to_string(), // duplicate
+            "c".to_string(),
+        ];
+        // only "a" and "c" exist in the store
+        let present = |k: &str| matches!(k, "a" | "c");
+        assert_eq!(missing_from_store(&referenced, present), vec!["b"]);
+
+        // everything present -> nothing missing
+        assert!(missing_from_store(&referenced, |_| true).is_empty());
+
+        // nothing present -> all reported once, in first-occurrence order
+        assert_eq!(
+            missing_from_store(&referenced, |_| false),
+            vec!["a", "b", "c"]
+        );
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -564,6 +564,38 @@ B = "b"
 }
 
 #[test]
+fn profile_show_warns_on_secret_missing_from_store() {
+    let dir = fresh_store();
+    let cfg = tempfile::tempdir().unwrap();
+    // store has "present" but not "absent"
+    llms()
+        .env("LLM_SECRETS_DIR", dir.path())
+        .args(["set", "present", "--stdin"])
+        .write_stdin("x")
+        .assert()
+        .success();
+    write_profiles(
+        cfg.path(),
+        r#"
+[demo]
+secrets = ["present", "absent"]
+ttl = "8h"
+"#,
+    );
+
+    llms()
+        .env("LLM_SECRETS_DIR", dir.path())
+        .env("LLM_SECRETS_CONFIG_DIR", cfg.path())
+        .args(["profile", "show", "demo"])
+        .assert()
+        .success() // a warning, never an error
+        .stdout(predicate::str::contains("profile:  demo"))
+        .stderr(predicate::str::contains("not in the store"))
+        .stderr(predicate::str::contains("absent"))
+        .stderr(predicate::str::contains("present").not());
+}
+
+#[test]
 fn profile_mint_then_use_via_env() {
     let dir = fresh_store();
     let cfg = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## What
`profile show` now cross-checks every secret a profile references against the live store and **warns** about any that are missing (yellow on a TTY, plain in pipes/CI).

## Why
Closes #16. ADR 0008 runs this check at *mint* time; surfacing it at `show` time too catches a dangling reference before you try to use the profile. It is a **warning, never an error** — `show` still works with no store at all (`StoreNotFound` is ignored).

## How
- `missing_from_store(referenced, exists)` — pure, deduped, order-preserving helper (unit-tested).
- `cmd_profile_show` loads the store and warns on any missing referenced secret; `warn()` is TTY/`NO_COLOR`-aware (no new dependency).
- Integration test: store has `present`, profile references `present` + `absent` → warning names only `absent`, command still succeeds.

## Verification
`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all clean (28 integration + unit). Manual run confirms the in-store secret is silent and the missing one warns at exit 0.