### PR TITLE
ADR 0009 + 0010 — v3.1 design decisions (MCP write tools; fail-closed audit)

### DIFF
--- a/docs/adr/0009-no-mcp-write-tools.md
+++ b/docs/adr/0009-no-mcp-write-tools.md
@@ -1,0 +1,54 @@
+# ADR 0009 — No secret-mutating MCP tools (MCP stays read/exec-only)
+
+- **Status**: Accepted
+- **Date**: 2026-06-13
+- **Builds on**: ADR 0002 (no `get` command), ADR 0005 (MCP server)
+- **Implemented in**: n/a — this ADR decides *not* to build a feature.
+
+## Context
+
+The MCP server (ADR 0005) is the agent-facing surface of `llms`. By design it
+exposes only tools that never return plaintext on a channel an agent could
+exfiltrate (ADR 0002): inspect/list, and `exec`-style injection into a child
+process. There is deliberately no way for an agent to *read* a secret value.
+
+The question (#18) is the mirror image: should the MCP surface gain *write*
+tools — `set` and `delete` — gated by an `mcp.write` policy field, so an agent
+could provision or remove secrets?
+
+### What we considered
+
+- **Expose `set`/`delete` over MCP, gated by `mcp.write` (default deny).** Adds a
+  policy knob; agents with the grant could create and delete store entries.
+- **Expose them freely.** Rejected outright — incompatible with the threat model.
+
+## Decision
+
+**Do not expose secret-mutating tools over MCP.** `set` and `delete` remain
+**CLI-only**, i.e. human-driven. The MCP surface stays read/exec-only.
+
+Rationale:
+
+- **Blast radius vs. benefit.** `delete` is destructive and `set` can silently
+  overwrite a live credential. Handing those to a confused or compromised agent
+  is high-risk; the benefit (an agent provisioning its own secret) is niche.
+- **Roles.** Provisioning a secret is a human onboarding step. Agents *consume*
+  secrets; they do not manage the store. Keeping that boundary keeps the
+  agent-facing surface minimal and auditable.
+- **No consumer.** Nothing concrete needs this today. We do not add speculative
+  attack surface to a security tool.
+
+**If a real need arises**, the shape is specified in advance so the next ADR can
+move fast: a `mcp.write` policy field **defaulting to deny**; `set` and `delete`
+as *separate* grants (deleting is strictly more dangerous than setting); every
+write still audited; and a superseding ADR recording the consumer that justified
+it. None of this is built now.
+
+## Consequences
+
+- The MCP surface remains small and read/exec-only — easy to reason about.
+- Agents cannot mutate the store; an over-permissioned or compromised agent
+  cannot delete or overwrite credentials.
+- Humans use the CLI (`llms set` / `llms delete`) for all store mutation.
+- **Revisit trigger:** a concrete automation that must provision secrets with no
+  human in the loop. Until then, this stays Accepted.

--- a/docs/adr/0010-fail-closed-audit.md
+++ b/docs/adr/0010-fail-closed-audit.md
@@ -1,0 +1,67 @@
+# ADR 0010 — Audit durability: best-effort by default, opt-in fail-closed
+
+- **Status**: Accepted
+- **Date**: 2026-06-13
+- **Builds on**: ADR 0004 (session identity); leases & audit (#7/#8)
+- **Implemented in**: decision only — implementation tracked in #26.
+
+## Context
+
+Every secret access is meant to leave an audit record (`lease::audit`). Today
+the access-path call sites discard the result:
+
+```rust
+let _ = crate::lease::audit("exec.inject", &ctx, None); // src/cli.rs
+let _ = lease::audit("mcp.peek", &ctx, None);           // src/mcp.rs
+```
+
+So a read **succeeds even if its audit entry cannot be written** — the current
+behaviour is fail-**open**, despite the `audit()` doc comment implying the
+opposite. #19 asks whether we should fail **closed**: refuse the operation when
+the access cannot be recorded.
+
+### The tradeoff
+
+- **Fail-closed** guarantees "no unlogged access" — valuable for high-assurance
+  and compliance deployments. But it introduces a **denial-of-service surface**:
+  a full disk, a read-only filesystem, or a permissions slip on the audit path
+  makes *every* secret inaccessible. The audit log becomes a single point of
+  failure for availability.
+- **Fail-open** preserves availability but permits unlogged access in exactly
+  those failure modes.
+
+### What we considered
+
+- **Always fail-closed.** Strong guarantee, but the DoS surface is the wrong
+  default for the common dev-tool case (a developer's laptop, CI runner).
+- **Always fail-open.** The status quo; no integrity guarantee for compliance.
+- **Fail-open default + opt-in strict.** Each consumer picks the tradeoff.
+
+## Decision
+
+**Fail-open stays the default; add an opt-in strict (fail-closed) mode.**
+
+- The default secret-access path remains best-effort: an audit-write failure is
+  swallowed (with a warning on stderr) and the operation proceeds. This keeps
+  availability and avoids the DoS surface for the common case.
+- Opt-in via **`LLM_SECRETS_AUDIT_STRICT=1`**: on the secret-access path, an
+  audit-write failure propagates and the operation fails **closed**. For
+  high-assurance deployments that need a hard "no unlogged access" guarantee.
+- Access-path audits route through a `record()` helper that honours strict mode;
+  the `audit()` doc comment is corrected to describe the real (fail-open)
+  default.
+
+This mirrors the opt-in **strict-leases** model (ADR-consistent): safe,
+available default; one switch for the stricter posture. As with leases, a future
+major version can flip the default if the landscape calls for it.
+
+Scope note: this applies to *secret-access* audits (`exec.inject`, `mcp.peek`).
+Post-hoc audits of actions that already completed (mint, lease-grant, revoke) are
+out of scope — failing them closed after the fact buys nothing.
+
+## Consequences
+
+- Default behaviour is unchanged; no new DoS surface for existing users.
+- High-assurance users get a hard guarantee via a single environment variable.
+- The doc/behaviour mismatch in `audit()` is resolved.
+- Implementation is tracked separately (#26); this ADR is the decision only.


### PR DESCRIPTION
Two pure-documentation ADRs resolving the v3.1 `needs-adr` issues. Bundled because neither carries code and both are the same decision batch.

## ADR 0009 — No MCP write tools (Closes #18)
**Decision: decline.** `set`/`delete` are not exposed over MCP; secret mutation stays CLI-only (human-driven). MCP remains read/exec-only. High blast-radius (`delete`) for niche benefit, no concrete consumer. Documents the deny-by-default `mcp.write` gate as the future shape if needed.

## ADR 0010 — Fail-closed audit (Closes #19)
**Decision: fail-open default + opt-in strict.** Today the access path already discards audit errors (fail-open) despite the doc comment. Keep that default (avoids the DoS surface where an unwritable audit path bricks all secret access); add `LLM_SECRETS_AUDIT_STRICT=1` to fail closed, mirroring the strict-leases pattern. The decision is here; implementation is tracked in #26.

No behavioural change ships in this PR — docs only.