### PR TITLE
Opt-in fail-closed audit (LLM_SECRETS_AUDIT_STRICT) — ADR 0010

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - **Strict-mode leases** (#15). `exec --leased` (also `exec --profile … --leased` and `profile exec … --leased`) now requires a current lease for every injected secret and **fails closed** if none is held. An expired lease counts as no lease. The default `exec` path is unchanged — strict mode is opt-in.
 - **`profile show` cross-checks the store** (#16). `profile show` now warns (yellow on a TTY, plain otherwise) when a profile references a secret that does not exist in the live store. It stays a warning, never an error, so `show` still works without a store.
+- **Opt-in fail-closed audit** (#26, ADR 0010). Set `LLM_SECRETS_AUDIT_STRICT=1` to make a failed audit write on the secret-access path fail the operation closed. The default is unchanged (best-effort/fail-open, now with a stderr warning on failure).
 
 ## [3.0.0] — 2026-04-10
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -661,7 +661,7 @@ fn cmd_exec(
             .get(secret_key)
             .ok_or_else(|| Error::KeyNotFound(secret_key.to_string()))?;
         process.env(env_var, value);
-        let _ = crate::lease::audit(event, &ctx, None);
+        crate::lease::record(event, &ctx, None)?;
     }
 
     // Drop the decrypted store before exec'ing the child so plaintext lives

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -151,9 +151,40 @@ pub struct AuditEntry {
     pub note: Option<String>,
 }
 
-/// Append a single audit record. Best-effort: if the file cannot be opened
-/// for append we still return Err so callers can decide whether to fail
-/// the operation. (Default: yes — auditability is load-bearing.)
+/// `true` when strict (fail-closed) auditing is requested via
+/// `LLM_SECRETS_AUDIT_STRICT` (`1` or `true`). See ADR 0010.
+pub fn audit_strict() -> bool {
+    std::env::var("LLM_SECRETS_AUDIT_STRICT")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Apply the ADR 0010 audit-durability policy to an audit result: in strict
+/// mode an audit-write failure propagates (fail closed); otherwise it is
+/// swallowed with a stderr warning (fail open, the default).
+fn apply_audit_policy(strict: bool, result: Result<()>) -> Result<()> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) if strict => Err(e),
+        Err(e) => {
+            eprintln!("warning: audit write failed (continuing): {e}");
+            Ok(())
+        }
+    }
+}
+
+/// Record an audit entry on the secret-access path, honouring the ADR 0010
+/// policy: fail-open by default, fail-closed under `LLM_SECRETS_AUDIT_STRICT`.
+/// Prefer this over calling [`audit`] directly from access paths.
+pub fn record(event: &str, ctx: &Context, note: Option<String>) -> Result<()> {
+    apply_audit_policy(audit_strict(), audit(event, ctx, note))
+}
+
+/// Append a single audit record. Returns `Err` if the entry cannot be written.
+///
+/// By default the secret-access path is fail-**open**: callers route through
+/// [`record`], which swallows the error (with a warning) unless
+/// `LLM_SECRETS_AUDIT_STRICT` is set. See ADR 0010.
 pub fn audit(event: &str, ctx: &Context, note: Option<String>) -> Result<()> {
     let path = audit_path()?;
     let parent = path
@@ -325,5 +356,17 @@ mod tests {
             }],
         };
         assert!(expired.require_active("live").is_err());
+    }
+
+    #[test]
+    fn audit_policy_fails_closed_only_in_strict_mode() {
+        let err = || Err(crate::error::Error::Other("disk full".into()));
+        // success always passes through
+        assert!(apply_audit_policy(false, Ok(())).is_ok());
+        assert!(apply_audit_policy(true, Ok(())).is_ok());
+        // default (fail-open): an audit error is swallowed
+        assert!(apply_audit_policy(false, err()).is_ok());
+        // strict (fail-closed): the error propagates
+        assert!(apply_audit_policy(true, err()).is_err());
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -208,7 +208,7 @@ fn call_tool(name: &str, args: &Value) -> Result<Value> {
             let value = st
                 .get(key)
                 .ok_or_else(|| crate::error::Error::KeyNotFound(key.to_string()))?;
-            let _ = lease::audit("mcp.peek", &ctx, None);
+            lease::record("mcp.peek", &ctx, None)?;
             Ok(text_result(store::mask(value, chars)))
         }
 


### PR DESCRIPTION
Implements the decision in ADR 0010. Closes #26.

Access-path audits route through `lease::record()`: **fail-open by default** (warn on failure, continue), **fail-closed** under `LLM_SECRETS_AUDIT_STRICT=1`. Default behaviour unchanged apart from the new warning. Unit test covers the policy; manual check confirms default warns-and-continues while strict refuses (verified by sabotaging the audit sink).