### PR TITLE
feat: glob support in the repo caveat matcher (adjoint/*)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - **Strict-mode leases** (#15). `exec --leased` (also `exec --profile … --leased` and `profile exec … --leased`) now requires a current lease for every injected secret and **fails closed** if none is held. An expired lease counts as no lease. The default `exec` path is unchanged — strict mode is opt-in.
 - **`profile show` cross-checks the store** (#16). `profile show` now warns (yellow on a TTY, plain otherwise) when a profile references a secret that does not exist in the live store. It stays a warning, never an error, so `show` still works without a store.
 - **Opt-in fail-closed audit** (#26, ADR 0010). Set `LLM_SECRETS_AUDIT_STRICT=1` to make a failed audit write on the secret-access path fail the operation closed. The default is unchanged (best-effort/fail-open, now with a stderr warning on failure).
+- **Glob support in the `repo` caveat matcher** (#22, ADR 0008 Phase 2). `repo = "adjoint/*"` in a profile (or `RepoEq` on a minted macaroon) now matches any repo starting with `adjoint/`. Exact-match patterns (no `*`) are unchanged.
 
 ## [3.0.0] — 2026-04-10
 

--- a/docs/adr/0008-toml-profiles.md
+++ b/docs/adr/0008-toml-profiles.md
@@ -225,7 +225,8 @@ These are mentioned for context only. Each will get its own ADR if and when need
 
 - `profiles.d/<name>.toml` directory layout for per-machine overrides
 - `EnvMap` caveat for fully self-contained portable profiles (cross-machine delegation)
-- Glob support in `repo` matcher (`adjoint/*`) — Phase 1 is exact match only
+- ~~Glob support in `repo` matcher (`adjoint/*`) — Phase 1 is exact match only~~
+  **Shipped** — see `glob_match` in `src/macaroon.rs` (#22)
 - Hierarchical profiles / inheritance (`iba-prod extends iba`)
 - Auto-cache of recently-minted macaroons to avoid re-mint cost on hot paths
 - Maximum-TTL enforcement as a session policy

--- a/src/macaroon.rs
+++ b/src/macaroon.rs
@@ -172,7 +172,7 @@ impl Caveat {
                     Err(format!("expires_at: token expired at {}", t.to_rfc3339()))
                 }
             }
-            Caveat::RepoEq(r) => eq_or_err("repo", &ctx.repo, r),
+            Caveat::RepoEq(r) => glob_or_err("repo", &ctx.repo, r),
             Caveat::BranchEq(b) => eq_or_err("branch", &ctx.branch, b),
             Caveat::AgentEq(a) => eq_or_err("agent", &ctx.agent, a),
             Caveat::WhoEq(w) => eq_or_err("who", &ctx.who, w),
@@ -194,6 +194,7 @@ impl Caveat {
             Caveat::SecretEq(s) => format!("secret == {s}"),
             Caveat::SecretsIn(list) => format!("secret in {list:?}"),
             Caveat::ExpiresAt(t) => format!("expires at {}", t.to_rfc3339()),
+            Caveat::RepoEq(r) if r.contains('*') => format!("repo ~ {r}"),
             Caveat::RepoEq(r) => format!("repo == {r}"),
             Caveat::BranchEq(b) => format!("branch == {b}"),
             Caveat::AgentEq(a) => format!("agent == {a}"),
@@ -208,6 +209,52 @@ fn eq_or_err(field: &str, actual: &str, expected: &str) -> std::result::Result<(
     } else {
         Err(format!("{field}_eq: '{actual}' != '{expected}'"))
     }
+}
+
+/// Exact match, or glob match if `pattern` contains `*` (e.g. `adjoint/*`).
+/// Used by `RepoEq` — Phase 2 of ADR 0008 (#22).
+fn glob_or_err(field: &str, actual: &str, pattern: &str) -> std::result::Result<(), String> {
+    if glob_match(pattern, actual) {
+        Ok(())
+    } else if pattern.contains('*') {
+        Err(format!(
+            "{field}_glob: '{actual}' does not match '{pattern}'"
+        ))
+    } else {
+        Err(format!("{field}_eq: '{actual}' != '{pattern}'"))
+    }
+}
+
+/// Minimal glob: `*` matches any sequence (including empty); every other
+/// character matches literally. No `?`, character classes, or escaping —
+/// the repo matcher only ever needs `owner/*` style prefixes.
+fn glob_match(pattern: &str, value: &str) -> bool {
+    if !pattern.contains('*') {
+        return pattern == value;
+    }
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut pos = 0usize;
+    let last = parts.len() - 1;
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            if !value[pos..].starts_with(part) {
+                return false;
+            }
+            pos += part.len();
+        } else if i == last {
+            if !value[pos..].ends_with(part) {
+                return false;
+            }
+        } else if let Some(found) = value[pos..].find(part) {
+            pos += found + part.len();
+        } else {
+            return false;
+        }
+    }
+    true
 }
 
 fn sort_value(v: serde_json::Value) -> serde_json::Value {
@@ -530,6 +577,44 @@ mod tests {
                 .check(&ctx_for("x"))
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn repo_eq_exact_match_unchanged() {
+        assert!(
+            Caveat::RepoEq("acme/billing".into())
+                .check(&ctx_for("x"))
+                .is_ok()
+        );
+        assert!(
+            Caveat::RepoEq("acme/other".into())
+                .check(&ctx_for("x"))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn repo_eq_glob_matches_owner_prefix() {
+        assert!(Caveat::RepoEq("acme/*".into()).check(&ctx_for("x")).is_ok());
+        assert!(
+            Caveat::RepoEq("other/*".into())
+                .check(&ctx_for("x"))
+                .is_err()
+        );
+        assert!(Caveat::RepoEq("*".into()).check(&ctx_for("x")).is_ok());
+    }
+
+    #[test]
+    fn glob_match_cases() {
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("acme/*", "acme/billing"));
+        assert!(!glob_match("acme/*", "other/billing"));
+        assert!(glob_match("*/billing", "acme/billing"));
+        assert!(glob_match("a*c", "abc"));
+        assert!(glob_match("a*c", "ac"));
+        assert!(!glob_match("a*c", "abd"));
+        assert!(glob_match("exact", "exact"));
+        assert!(!glob_match("exact", "other"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #22.

## Summary
- `RepoEq` now matches via a minimal glob (`*` = any sequence) when the pattern contains `*` — e.g. `repo = "adjoint/*"` in a profile matches every repo under that owner
- Exact-match patterns (no `*`) are byte-for-byte unchanged
- No new `Caveat` variant, no macaroon serialisation change — purely a semantics change to how `RepoEq` is checked, per ADR 0008 Phase 2
- Hand-rolled matcher, no new dependency (single wildcard type, no need for the `glob` crate)

## Test plan
- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test --all` — all pass (31 unit + 28 CLI integration)
- [x] New tests: `glob_match_cases`, `repo_eq_glob_matches_owner_prefix`, `repo_eq_exact_match_unchanged`