### PR TITLE
feat: profiles.d/ per-machine profile overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 ### Added
 
 - **Profile inheritance — `extends`** (#20, ADR 0008 Phase 2). A profile can `extends = "parent"` to inherit its `secrets`, `env`, `ttl`, and `repo`/`branch`/`agent` caveats. Additive-only: `secrets` may narrow to a subset of the parent's, `ttl` may shorten but never lengthen, and `repo`/`branch`/`agent` may only be set by the child if the parent left them unset — never overridden. Cycles and unknown parents are rejected at load time.
+- **`profiles.d/` per-machine overrides** (#21, ADR 0008 Phase 2). Any `*.toml` file dropped in `~/.config/llm-secrets/profiles.d/` is layered on top of `profiles.toml`: a profile name defined there fully replaces the same-named entry (or adds a new machine-local profile). Meant for per-machine config that isn't dotfile-synced. The same name in two different `profiles.d` files is rejected as ambiguous; `profiles.toml` itself is now optional if `profiles.d/` alone defines at least one profile.
 
 ## [3.1.0] — 2026-07-22
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -128,6 +128,12 @@ profile can narrow what it inherits (fewer secrets, shorter ttl, an
 extra `repo`/`branch`/`agent` restriction) but can never widen or
 override something the parent already restricts.
 
+For per-machine differences (not dotfile-synced), drop override files in
+`~/.config/llm-secrets/profiles.d/*.toml`. Any profile name defined there
+fully replaces the same-named entry from `profiles.toml` — this is a
+config-precedence question, not a security boundary, so there's no
+narrowing rule here (unlike `extends`).
+
 ### That's it
 
 For use case 1, the commands you'll type are:

--- a/docs/adr/0008-toml-profiles.md
+++ b/docs/adr/0008-toml-profiles.md
@@ -223,7 +223,11 @@ The `command` field captures `argv[0]` only — never arguments, which may conta
 
 These are mentioned for context only. Each will get its own ADR if and when needed.
 
-- `profiles.d/<name>.toml` directory layout for per-machine overrides
+- ~~`profiles.d/<name>.toml` directory layout for per-machine overrides~~
+  **Shipped** — see `read_profiles_file()` in `src/profile.rs` (#21). Unlike
+  `extends`, this is a config-precedence question, not a security boundary:
+  a name defined in `profiles.d/*.toml` fully replaces the same-named entry
+  from `profiles.toml`, no narrowing constraint.
 - `EnvMap` caveat for fully self-contained portable profiles (cross-machine delegation)
 - ~~Glob support in `repo` matcher (`adjoint/*`) — Phase 1 is exact match only~~
   **Shipped** — see `glob_match` in `src/macaroon.rs` (#22)

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -12,10 +12,19 @@
 //! `~/.config/llm-secrets/profiles.toml`). The store at `~/.llm-secrets/`
 //! is the security boundary; profiles.toml is non-secret config — diffable,
 //! vimmable, dotfile-managed. Stealing it confers no authority.
+//!
+//! An optional `profiles.d/*.toml` directory next to `profiles.toml` holds
+//! per-machine overrides (not synced by dotfiles): each file is a map of
+//! `name -> profile`, same shape as `profiles.toml`, and any name it
+//! defines fully replaces the same-named entry from `profiles.toml` (or
+//! adds a new machine-local profile if the name doesn't exist there). This
+//! is a config-loading precedence question, not a security boundary, so —
+//! unlike `extends` — there is no narrowing constraint: the override simply
+//! wins. See `docs/adr/0008-toml-profiles.md`, Phase 2.
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use chrono::Duration;
 use serde::Deserialize;
@@ -24,6 +33,7 @@ use crate::error::{Error, Result};
 use crate::macaroon::{Caveat, parse_duration};
 
 const PROFILES_FILENAME: &str = "profiles.toml";
+const PROFILES_D_DIRNAME: &str = "profiles.d";
 const CONFIG_DIR_ENV: &str = "LLM_SECRETS_CONFIG_DIR";
 
 /// Resolve the config directory. Honours `$LLM_SECRETS_CONFIG_DIR`,
@@ -42,6 +52,10 @@ pub fn config_dir() -> Result<PathBuf> {
 
 pub fn profiles_path() -> Result<PathBuf> {
     Ok(config_dir()?.join(PROFILES_FILENAME))
+}
+
+pub fn profiles_d_dir() -> Result<PathBuf> {
+    Ok(config_dir()?.join(PROFILES_D_DIRNAME))
 }
 
 /// In-memory representation of one profile, ready to be turned into caveats.
@@ -84,17 +98,60 @@ struct ProfileToml {
     agent: Option<String>,
 }
 
+fn parse_profiles_toml(path: &Path, text: &str) -> Result<BTreeMap<String, ProfileToml>> {
+    toml::from_str(text).map_err(|e| Error::Other(format!("{} invalid: {e}", path.display())))
+}
+
+/// Reads `profiles.toml`, then layers any `profiles.d/*.toml` overrides on
+/// top (sorted by filename for determinism). A name defined in `profiles.d`
+/// fully replaces the same-named entry from `profiles.toml` — that's the
+/// point (per-machine override) — but the same name appearing in two
+/// different `profiles.d` files is almost certainly a mistake, so that's
+/// rejected loudly rather than silently picked by sort order.
 fn read_profiles_file() -> Result<BTreeMap<String, ProfileToml>> {
     let path = profiles_path()?;
-    if !path.exists() {
+    let file_exists = path.exists();
+    let mut map: BTreeMap<String, ProfileToml> = if file_exists {
+        let text = fs::read_to_string(&path)?;
+        parse_profiles_toml(&path, &text)?
+    } else {
+        BTreeMap::new()
+    };
+
+    let d_dir = profiles_d_dir()?;
+    let mut had_d_files = false;
+    if d_dir.is_dir() {
+        let mut entries: Vec<PathBuf> = fs::read_dir(&d_dir)?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("toml"))
+            .collect();
+        entries.sort();
+        had_d_files = !entries.is_empty();
+
+        let mut override_sources: BTreeMap<String, PathBuf> = BTreeMap::new();
+        for file_path in entries {
+            let text = fs::read_to_string(&file_path)?;
+            let overrides = parse_profiles_toml(&file_path, &text)?;
+            for (name, t) in overrides {
+                if let Some(prev) = override_sources.insert(name.clone(), file_path.clone()) {
+                    return Err(Error::Other(format!(
+                        "profile '{name}' is defined in multiple profiles.d files: {} and {}",
+                        prev.display(),
+                        file_path.display()
+                    )));
+                }
+                map.insert(name, t);
+            }
+        }
+    }
+
+    if !file_exists && !had_d_files {
         return Err(Error::Other(format!(
             "no profiles file at {} — create one to use profiles",
             path.display()
         )));
     }
-    let text = fs::read_to_string(&path)?;
-    let map: BTreeMap<String, ProfileToml> =
-        toml::from_str(&text).map_err(|e| Error::Other(format!("profiles.toml invalid: {e}")))?;
     Ok(map)
 }
 
@@ -526,6 +583,91 @@ ttl = "1h"
         );
         let err = Profile::load("a").unwrap_err().to_string();
         assert!(err.contains("inheritance cycle"), "{err}");
+
+        // profiles.d: fully overrides a same-named entry from profiles.toml
+        let d_dir = dir.path().join("profiles.d");
+        let write_d = |filename: &str, body: &str| {
+            std::fs::create_dir_all(&d_dir).unwrap();
+            std::fs::write(d_dir.join(filename), body).unwrap();
+        };
+        std::fs::remove_dir_all(&d_dir).ok(); // clean slate between scenarios below
+        write(
+            r#"
+[iba]
+secrets = ["a", "b"]
+ttl = "8h"
+"#,
+        );
+        write_d(
+            "local.toml",
+            r#"
+[iba]
+secrets = ["z"]
+ttl = "30m"
+"#,
+        );
+        let p = Profile::load("iba").unwrap();
+        assert_eq!(p.secrets, vec!["z"]); // profiles.d wins, not merged field-by-field
+        assert_eq!(p.ttl, Duration::minutes(30));
+
+        // profiles.d: adds a profile that doesn't exist in profiles.toml at all
+        write_d(
+            "local.toml",
+            r#"
+[iba]
+secrets = ["z"]
+ttl = "30m"
+
+[homelab]
+secrets = ["a"]
+ttl = "1h"
+"#,
+        );
+        let p = Profile::load("homelab").unwrap();
+        assert_eq!(p.secrets, vec!["a"]);
+
+        // profiles.d: same name defined in two different files is rejected
+        std::fs::remove_dir_all(&d_dir).ok();
+        write_d(
+            "a.toml",
+            r#"
+[iba]
+secrets = ["a"]
+ttl = "1h"
+"#,
+        );
+        write_d(
+            "b.toml",
+            r#"
+[iba]
+secrets = ["b"]
+ttl = "1h"
+"#,
+        );
+        let err = Profile::load("iba").unwrap_err().to_string();
+        assert!(
+            err.contains("defined in multiple profiles.d files"),
+            "{err}"
+        );
+
+        // profiles.d alone (no profiles.toml) is sufficient
+        std::fs::remove_dir_all(&d_dir).ok();
+        std::fs::remove_file(dir.path().join("profiles.toml")).ok();
+        write_d(
+            "local.toml",
+            r#"
+[solo]
+secrets = ["a"]
+ttl = "1h"
+"#,
+        );
+        let p = Profile::load("solo").unwrap();
+        assert_eq!(p.secrets, vec!["a"]);
+
+        // Neither profiles.toml nor profiles.d present: still a clear error
+        std::fs::remove_dir_all(&d_dir).ok();
+        let err = Profile::load("solo").unwrap_err().to_string();
+        assert!(err.contains("no profiles file"), "{err}");
 
         unsafe {
             match prev {


### PR DESCRIPTION
Closes #21.

## Summary
- `~/.config/llm-secrets/profiles.d/*.toml` is now read (if present) and layered on top of `profiles.toml`
- Any profile name defined in a `profiles.d` file fully replaces the same-named entry from `profiles.toml`, or adds a new machine-local profile if the name doesn't exist there
- Unlike `extends`, this is a config-loading precedence question, not a security boundary — no narrowing constraint, the override simply wins
- The same profile name defined in two different `profiles.d` files is rejected as ambiguous rather than silently resolved by sort order
- `profiles.toml` is now optional if `profiles.d/` alone defines at least one profile (previously required to exist even if empty)
- No changes to `Caveat`, macaroon format, or `extends` behaviour

## Test plan
- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test --all` — all pass (31 unit + 28 CLI integration)
- [x] New scenarios in `profile::tests::file_system_load_paths`: full override of a base profile, new machine-local profile, duplicate-name-across-files rejected, profiles.d alone (no profiles.toml) works, neither present still errors clearly